### PR TITLE
Update ProductRepositoryImpl.java

### DIFF
--- a/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryImpl.java
@@ -733,8 +733,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 				 **********************************/
 				
 				// QECI Fix: Use StringBuilder
-				parameterMsgA.append("val").append(count).append(attributeCriteria.getAttributeCode())
-				parameterMsgB.append("%").append(attributeCriteria.getAttributeValue()).append(%);
+				parameterMsgA.append("val").append(count).append(attributeCriteria.getAttributeCode());
+				parameterMsgB.append("%").append(attributeCriteria.getAttributeValue()).append("%");
 				countQ.setParameter(parameterMsgA.toString(), parameterMsgB.toString());
 				/*
     				countQ.setParameter("val" + count + attributeCriteria.getAttributeCode(),


### PR DESCRIPTION
Add missing semicolon and missing quotation marks around %-sign. This should fix these two errors:

[ERROR] /home/azureuser/shopizer_20240202_123037_mfa1/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryImpl.java:[736,119] ';' expected
[ERROR] /home/azureuser/shopizer_20240202_123037_mfa1/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryImpl.java:[737,112] illegal start of expression
[ERROR] /home/azureuser/shopizer_20240202_123037_mfa1/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryImpl.java:[737,113] illegal start of expression